### PR TITLE
Fix Grails application detection race on project startup

### DIFF
--- a/src/org/jetbrains/plugins/grails/structure/sync/GrailsStartupActivity.java
+++ b/src/org/jetbrains/plugins/grails/structure/sync/GrailsStartupActivity.java
@@ -17,6 +17,7 @@
 package org.jetbrains.plugins.grails.structure.sync;
 
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.externalSystem.service.project.manage.ExternalProjectsManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ModuleRootEvent;
 import com.intellij.openapi.roots.ModuleRootListener;
@@ -67,5 +68,14 @@ public final class GrailsStartupActivity implements StartupActivity.DumbAware {
 
     GrailsApplicationManager.getInstance(project).queueUpdate();
     TraitInjectorService.queueUpdate(project);
+
+    // Gradle-based applications are detected from external system data, which is loaded
+    // asynchronously on project open; recompute once it becomes available, otherwise
+    // applications stay undetected until the next manual Gradle sync.
+    ExternalProjectsManager.getInstance(project).runWhenInitialized(() -> {
+      GrailsApplicationManager.getInstance(project).queueUpdate();
+      TraitInjectorService.queueUpdate(project);
+    });
+
   }
 }


### PR DESCRIPTION
**Problem**

 When a Gradle-based Grails project is opened, the Grails toolbar actions (navigation shortcuts between domain classes, controllers, services, views and tests) stay disabled. They only  become active after manually triggering a Gradle re-sync (e.g. by touching build.gradle and reimporting), which has to be done every time the project is opened.

**Root cause**

GrailsStartupActivity queues the Grails application detection (GrailsApplicationManager.queueUpdate()) as soon as the project opens. For Gradle projects, however, detection relies on   external system project data (GrailsModuleData attached during Gradle sync), which is loaded asynchronously after project open. At the moment the startup activity runs, that data is not   available yet, so no Grails application is detected — and since nothing re-triggers detection afterwards, the plugin stays inactive until the next manual Gradle sync repopulates the data.

**Solution**

In GrailsStartupActivity, re-queue the detection once the external system data becomes available, using ExternalProjectsManager.runWhenInitialized():

```
  ExternalProjectsManager.getInstance(project).runWhenInitialized(() -> {
    GrailsApplicationManager.getInstance(project).queueUpdate();
    TraitInjectorService.queueUpdate(project);
  });
```

If the external system is already initialized, the callback runs immediately, so the behavior for non-Gradle projects and warm starts is unchanged. With this change, Grails applications  are detected right after project open and the toolbar actions are enabled without any manual re-sync.

**Testing**

Verified with ./gradlew runIde on IntelliJ IDEA Ultimate 2026.2: opening a Gradle-based Grails project now enables the toolbar actions immediately after startup, without forcing a Gradle  re-sync.
