### PR TITLE
Fix HQL navigation and rename for GORM domains in Grails 3+

### DIFF
--- a/hibernate/resources/intellij.groovy.grails.hibernate.xml
+++ b/hibernate/resources/intellij.groovy.grails.hibernate.xml
@@ -21,6 +21,7 @@
 
   <extensions defaultExtensionNs="com.intellij">
     <persistence.packagesProvider implementation="com.intellij.groovy.grails.hibernate.GormSessionFactoryContributor"/>
+    <postStartupActivity implementation="com.intellij.groovy.grails.hibernate.Grails3HibernateFacetActivity"/>
   </extensions>
 
   <extensions defaultExtensionNs="org.intellij.grails">

--- a/hibernate/src/com/intellij/groovy/grails/hibernate/Grails3HibernateFacetActivity.java
+++ b/hibernate/src/com/intellij/groovy/grails/hibernate/Grails3HibernateFacetActivity.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.intellij.groovy.grails.hibernate;
+
+import com.intellij.facet.FacetManager;
+import com.intellij.facet.ModifiableFacetModel;
+import com.intellij.hibernate.facet.HibernateFacet;
+import com.intellij.hibernate.facet.HibernateFacetType;
+import com.intellij.jpa.facet.JpaFacet;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.application.WriteAction;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ProjectFileIndex;
+import com.intellij.openapi.startup.StartupActivity;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.messages.MessageBusConnection;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.plugins.grails.structure.GrailsApplication;
+import org.jetbrains.plugins.grails.structure.GrailsApplicationListener;
+import org.jetbrains.plugins.grails.structure.GrailsApplicationManager;
+import org.jetbrains.plugins.grails.structure.Grails3Application;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Ensures modules that host a Grails 3+ application carry a Hibernate facet, so that the GORM
+ * persistence bridge ({@code GormSessionFactoryContributor} -> {@code GormPersistenceMapping} ->
+ * {@code GormEntity}) is activated and injected HQL can resolve domain classes and their properties
+ * (navigation, find usages and rename).
+ *
+ * <p>For legacy Grails 2.x modules this facet is added through {@link GormHibernateFacetProvider}
+ * during the MVC module-structure sync ({@code MvcProjectStructure.setupFacets}). That sync does not
+ * run for Grails 3+ modules imported via Gradle, so the facet - and therefore the persistence model
+ * exposing GORM entities - was never created there. This activity fills that gap without touching the
+ * Gradle-managed source roots.
+ */
+final class Grails3HibernateFacetActivity implements StartupActivity.DumbAware {
+
+  private static final String GORM_FACET_NAME = "Gorm";
+
+  @Override
+  public void runActivity(@NotNull Project project) {
+    if (ApplicationManager.getApplication().isUnitTestMode()) return;
+
+    MessageBusConnection connection = project.getMessageBus().connect();
+    connection.subscribe(GrailsApplicationListener.TOPIC, () -> ensureGormFacets(project));
+
+    // Applications may already have been discovered (or recomputed by GrailsStartupActivity)
+    // before this activity got a chance to subscribe above.
+    ApplicationManager.getApplication().invokeLater(() -> ensureGormFacets(project), project.getDisposed());
+  }
+
+  private static void ensureGormFacets(@NotNull Project project) {
+    if (project.isDisposed()) return;
+
+    Set<Module> modules = ReadAction.compute(() -> {
+      Set<Module> result = new LinkedHashSet<>();
+      ProjectFileIndex fileIndex = ProjectFileIndex.getInstance(project);
+      for (GrailsApplication application : GrailsApplicationManager.getInstance(project).getApplications()) {
+        if (!(application instanceof Grails3Application) || !application.isValid()) continue;
+        VirtualFile appRoot = application.getAppRoot();
+        Module module = fileIndex.getModuleForFile(appRoot);
+        if (module != null) result.add(module);
+      }
+      return result;
+    });
+
+    for (Module module : modules) {
+      ensureGormFacet(module);
+    }
+  }
+
+  private static void ensureGormFacet(@NotNull Module module) {
+    if (module.isDisposed() || hasPersistenceFacet(module)) return;
+
+    ApplicationManager.getApplication().invokeLater(() -> {
+      if (module.isDisposed() || hasPersistenceFacet(module)) return;
+
+      WriteAction.run(() -> {
+        FacetManager facetManager = FacetManager.getInstance(module);
+        ModifiableFacetModel model = facetManager.createModifiableModel();
+        HibernateFacetType facetType = HibernateFacetType.getInstance();
+        HibernateFacet facet = facetType.createFacet(module, GORM_FACET_NAME, facetType.createDefaultConfiguration(), null);
+        model.addFacet(facet);
+        model.commit();
+      });
+    }, module.getDisposed());
+  }
+
+  private static boolean hasPersistenceFacet(@NotNull Module module) {
+    return ReadAction.compute(() -> {
+      FacetManager facetManager = FacetManager.getInstance(module);
+      return !facetManager.getFacetsByType(HibernateFacet.ID).isEmpty()
+             || !facetManager.getFacetsByType(JpaFacet.ID).isEmpty();
+    });
+  }
+}

--- a/langInjection/resources/META-INF/languageInjections.xml
+++ b/langInjection/resources/META-INF/languageInjections.xml
@@ -14,9 +14,12 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
+<!--
+  HQL injection into GORM find/findAll/executeQuery/executeUpdate is now performed
+  programmatically by org.jetbrains.plugins.grails.references.domain.GormHqlInjector.
+  The previous IntelliLang matcher relied on the synthetic "Gorm:DomainDescriptor:DynamicMethod"
+  light methods, which are only generated for GORM below 4; on GORM 4+ (Grails 3+) the finder
+  methods come from the GormEntity trait and are not marked, so this matcher never fired there.
+-->
 <component name="LanguageInjectionConfiguration">
-  <injection language="HQL" injector-id="groovy">
-    <display-name>Grails HQL injection</display-name>
-    <place><![CDATA[groovyElement().methodCallParameter(0, grLightMethod("Gorm:DomainDescriptor:DynamicMethod").withName(string().oneOf("find", "findAll", "executeQuery", "executeUpdate")))]]></place>
-  </injection>
 </component>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -321,6 +321,7 @@
 
     <multiHostInjector implementation="org.jetbrains.plugins.grails.lang.gsp.GspCssInjector"/>
     <multiHostInjector implementation="org.jetbrains.plugins.grails.references.constraints.GormRegexInjector"/>
+    <multiHostInjector implementation="org.jetbrains.plugins.grails.references.domain.GormHqlInjector"/>
 
     <gotoRelatedProvider implementation="org.jetbrains.plugins.grails.actions.GrailsGotoRelatedProvider"/>
 

--- a/src/org/jetbrains/plugins/grails/references/domain/GormHqlInjector.java
+++ b/src/org/jetbrains/plugins/grails/references/domain/GormHqlInjector.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jetbrains.plugins.grails.references.domain;
+
+import com.intellij.lang.Language;
+import com.intellij.lang.injection.MultiHostInjector;
+import com.intellij.lang.injection.MultiHostRegistrar;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.ElementManipulators;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.psi.util.PsiTypesUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.plugins.groovy.lang.psi.api.statements.arguments.GrArgumentList;
+import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.GrExpression;
+import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.GrMethodCall;
+import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.GrReferenceExpression;
+import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.literals.GrLiteral;
+import org.jetbrains.plugins.groovy.lang.psi.impl.statements.expressions.literals.GrLiteralImpl;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Injects the HQL language into the query string passed to GORM's {@code find}, {@code findAll},
+ * {@code executeQuery} and {@code executeUpdate} methods on domain classes, so that class and
+ * property names inside the query become real references (navigation, find usages and rename work).
+ *
+ * <p>This replaces the old IntelliLang XML injection which matched the synthetic
+ * {@code Gorm:DomainDescriptor:DynamicMethod} light methods. Those are only generated for GORM
+ * below 4 (see {@link GormAstTransformationContributor}); on GORM 4+ the finder methods come from
+ * the {@code GormEntity} trait and are not marked, so the XML matcher never fired. Resolving the
+ * domain class directly here keeps the behaviour working across all GORM/Grails versions.
+ */
+public final class GormHqlInjector implements MultiHostInjector {
+
+  private static final String HQL_LANGUAGE_ID = "HQL";
+
+  private static final Set<String> QUERY_METHODS = Set.of("find", "findAll", "executeQuery", "executeUpdate");
+
+  @Override
+  public void getLanguagesToInject(@NotNull MultiHostRegistrar registrar, @NotNull PsiElement context) {
+    GrLiteral literal = (GrLiteral)context;
+    if (!literal.isString()) return;
+
+    GrMethodCall call = getQueryCall(literal);
+    if (call == null) return;
+
+    GrReferenceExpression invoked = getInvokedReference(call);
+    if (invoked == null || !QUERY_METHODS.contains(invoked.getReferenceName())) return;
+
+    PsiClass domainClass = resolveDomainClass(invoked);
+    if (!GormUtils.isGormBean(domainClass)) return;
+
+    Language hql = Language.findLanguageByID(HQL_LANGUAGE_ID);
+    if (hql == null) return;
+
+    TextRange range = ElementManipulators.getValueTextRange(literal);
+    registrar.startInjecting(hql).addPlace(null, null, (GrLiteralImpl)literal, range).doneInjecting();
+  }
+
+  /**
+   * Returns the method call whose first positional argument is {@code literal}, or {@code null} when
+   * {@code literal} is not directly the first argument of a call.
+   */
+  private static @Nullable GrMethodCall getQueryCall(@NotNull GrLiteral literal) {
+    PsiElement parent = literal.getParent();
+    if (!(parent instanceof GrArgumentList)) return null;
+    if (!(parent.getParent() instanceof GrMethodCall call)) return null;
+
+    GrExpression[] arguments = call.getArgumentList().getExpressionArguments();
+    if (arguments.length == 0 || arguments[0] != literal) return null;
+
+    return call;
+  }
+
+  private static @Nullable GrReferenceExpression getInvokedReference(@NotNull GrMethodCall call) {
+    GrExpression invoked = call.getInvokedExpression();
+    return invoked instanceof GrReferenceExpression ref ? ref : null;
+  }
+
+  /**
+   * Determines the domain class a finder call is invoked on: the qualifier for {@code Book.find(...)},
+   * or the enclosing class for an unqualified {@code find(...)} inside a domain class body.
+   */
+  private static @Nullable PsiClass resolveDomainClass(@NotNull GrReferenceExpression invoked) {
+    GrExpression qualifier = invoked.getQualifierExpression();
+    if (qualifier == null) {
+      return PsiTreeUtil.getParentOfType(invoked, PsiClass.class);
+    }
+
+    if (qualifier instanceof GrReferenceExpression qualifierRef && qualifierRef.resolve() instanceof PsiClass psiClass) {
+      return psiClass;
+    }
+
+    return PsiTypesUtil.getPsiClass(qualifier.getType());
+  }
+
+  @Override
+  public @NotNull List<? extends Class<? extends PsiElement>> elementsToInjectIn() {
+    return List.of(GrLiteral.class);
+  }
+}

--- a/src/org/jetbrains/plugins/grails/references/domain/criteria/CriteriaBuilderUtil.java
+++ b/src/org/jetbrains/plugins/grails/references/domain/criteria/CriteriaBuilderUtil.java
@@ -29,6 +29,7 @@ import com.intellij.psi.PsiType;
 import com.intellij.psi.impl.source.tree.LeafPsiElement;
 import com.intellij.psi.util.InheritanceUtil;
 import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.psi.util.PsiTypesUtil;
 import com.intellij.util.SmartList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -120,7 +121,36 @@ public final class CriteriaBuilderUtil {
     if (CriteriaBuilderImplicitMemberContributor.isMine(method)) return true;
 
     PsiClass aClass = method.getContainingClass();
-    return aClass != null && CRITERIA_BUILDER_CLASS.equals(aClass.getQualifiedName());
+    if (aClass == null) return false;
+    if (CRITERIA_BUILDER_CLASS.equals(aClass.getQualifiedName())) return true;
+
+    // Many criteria DSL methods (eq, order, ...) are declared on a supertype/interface implemented by
+    // HibernateCriteriaBuilder (e.g. org.grails.datastore.mapping.query.api.Criteria) rather than on
+    // HibernateCriteriaBuilder itself, so method.getContainingClass() resolves to that supertype.
+    PsiClass hibCriteriaBuilder = JavaPsiFacade.getInstance(aClass.getProject()).findClass(CRITERIA_BUILDER_CLASS, method.getResolveScope());
+    return hibCriteriaBuilder != null && hibCriteriaBuilder.isInheritor(aClass, true);
+  }
+
+  /**
+   * Determines the domain class a GORM member call (e.g. {@code withCriteria}, {@code createCriteria})
+   * is invoked on: the qualifier for {@code Ddd.withCriteria { ... }}, or the enclosing class for an
+   * unqualified call inside a domain class body. Returns {@code null} unless that class is a GORM bean.
+   */
+  private static @Nullable PsiClass resolveGormMemberQualifierClass(@NotNull GrReferenceExpression invoked) {
+    GrExpression qualifier = invoked.getQualifierExpression();
+    PsiClass domainClass;
+
+    if (qualifier == null) {
+      domainClass = PsiTreeUtil.getParentOfType(invoked, PsiClass.class);
+    }
+    else if (qualifier instanceof GrReferenceExpression qualifierRef && qualifierRef.resolve() instanceof PsiClass psiClass) {
+      domainClass = psiClass;
+    }
+    else {
+      domainClass = PsiTypesUtil.getPsiClass(qualifier.getType());
+    }
+
+    return GormUtils.isGormBean(domainClass) ? domainClass : null;
   }
 
   public static @Nullable PsiClass findDomainClassByBuilderExpression(@Nullable GrExpression expression) {
@@ -152,10 +182,15 @@ public final class CriteriaBuilderUtil {
         if (!"createCriteria".equals(methodName)) return null;
 
         PsiMethod method = ((GrMethodCall)expression).resolveMethod();
-        if (!GrLightMethodBuilder.checkKind(method, DomainDescriptor.DOMAIN_DYNAMIC_METHOD)) return null;
-        //noinspection ConstantConditions
+        if (GrLightMethodBuilder.checkKind(method, DomainDescriptor.DOMAIN_DYNAMIC_METHOD)) {
+          //noinspection ConstantConditions
+          return ((GrLightMethodBuilder)method).getData();
+        }
 
-        return ((GrLightMethodBuilder)method).getData();
+        // GORM 4+: createCriteria() comes from the GormEntity trait as a real (non-light) method and
+        // is never marked DOMAIN_DYNAMIC_METHOD (that marker is only produced for GORM < 4, see
+        // GormAstTransformationContributor). Resolve the domain class directly from the qualifier instead.
+        return resolveGormMemberQualifierClass((GrReferenceExpression)invokedExpression);
       }
 
       if (expression instanceof GrNewExpression) {
@@ -227,6 +262,15 @@ public final class CriteriaBuilderUtil {
         if (NamedQueryDescriptor.NAMED_QUERY_METHOD_MARKER.equals(kind)) {
           return lightMethod.<NamedQueryDescriptor>getData().getDomainClass();
         }
+      }
+      else if ("withCriteria".equals(method.getName())) {
+        // GORM 4+: withCriteria comes from the GormEntity trait as a real (non-light) method and is
+        // never marked DOMAIN_DYNAMIC_METHOD (that marker is only produced for GORM < 4, see
+        // GormAstTransformationContributor). Without this, the closure body falls back to whatever
+        // generic (datastore-agnostic) type Groovy infers via @DelegatesTo, which lacks Hibernate-only
+        // members like createAlias and leaves property navigation broken.
+        PsiClass domainClass = resolveGormMemberQualifierClass(ieRef);
+        if (domainClass != null) return domainClass;
       }
 
       PsiClass namedCriteriaProxyClass = method.getContainingClass();

--- a/src/org/jetbrains/plugins/grails/references/domain/criteria/CriteriaPropertyReferenceProvider.java
+++ b/src/org/jetbrains/plugins/grails/references/domain/criteria/CriteriaPropertyReferenceProvider.java
@@ -17,7 +17,6 @@
 package org.jetbrains.plugins.grails.references.domain.criteria;
 
 import com.intellij.openapi.util.Condition;
-import com.intellij.openapi.util.Conditions;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiMethod;
@@ -32,16 +31,18 @@ public class CriteriaPropertyReferenceProvider extends GrailsMethodNamedArgument
 
   @Override
   public void register(GrailsMethodNamedArgumentReferenceProvider registrar) {
-    Condition<PsiMethod> condition = Conditions.or(
-      new ClassSourceCondition(CriteriaBuilderImplicitMemberContributor.CLASS_SOURCE),
-      new ClassNameCondition(CriteriaBuilderUtil.CRITERIA_BUILDER_CLASS)
-    );
+    // Not ClassNameCondition/ClassSourceCondition: several criteria DSL methods (eq, order, ...) are
+    // declared on a supertype/interface implemented by HibernateCriteriaBuilder (e.g.
+    // org.grails.datastore.mapping.query.api.Criteria) rather than on HibernateCriteriaBuilder itself,
+    // so an exact-class-name match misses them. CriteriaBuilderUtil.isCriteriaBuilderMethod accounts
+    // for that inheritance.
+    Condition<PsiMethod> condition = CriteriaBuilderUtil::isCriteriaBuilderMethod;
 
     registrar.register(0, this, condition,
                        // #CHECK# grails.orm.HibernateCriteriaBuilder
                        "property", "distinct", "avg", "calculatePropertyName", "count", "countDistinct", "groupProperty", "max", "min",
                        "sum", "gt", "ge", "lt", "le", "eq", "like", "rlike", "ilike", "in", "inList", "order", "sizeEq", "sizeGt", "sizeGe",
-                       "sizeLe", "sizeLt", "sizeNe", "ne", "notEqual", "between", "fetchMode",
+                       "sizeLe", "sizeLt", "sizeNe", "ne", "notEqual", "between", "fetchMode", "createAlias",
 
                            // From HibernateCriteriaBuilder.invokeMethod(...)
                        "isNull", "isNotNull", "isEmpty", "isNotEmpty");

--- a/test/org/jetbrains/plugins/groovy/grails/domain/GormHqlInjectionTest.java
+++ b/test/org/jetbrains/plugins/groovy/grails/domain/GormHqlInjectionTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jetbrains.plugins.groovy.grails.domain;
+
+import com.intellij.lang.injection.InjectedLanguageManager;
+import com.intellij.openapi.util.Pair;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.jetbrains.plugins.groovy.grails.GrailsTestCase;
+import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.literals.GrLiteral;
+
+import java.util.List;
+
+/**
+ * Verifies {@link org.jetbrains.plugins.grails.references.domain.GormHqlInjector}: the query string
+ * of a GORM {@code find}/{@code findAll}/{@code executeQuery}/{@code executeUpdate} call on a domain
+ * class receives an HQL language injection (which is what makes navigation and rename of domain
+ * classes/properties work from inside the query string).
+ */
+public class GormHqlInjectionTest extends GrailsTestCase {
+
+  private static final String HQL_LANGUAGE_ID = "HQL";
+
+  public void testExecuteQueryIsInjected() {
+    addDomain("class Book { String title }");
+    PsiFile file = configureByDomain("""
+                                       class Library {
+                                         def all() {
+                                           Book.executeQuery("from Book b where b.title = 'x'")
+                                         }
+                                       }
+                                       """);
+    assertInjectedLanguage(file, "from Book b where b.title = 'x'", HQL_LANGUAGE_ID);
+  }
+
+  public void testFindIsInjected() {
+    addDomain("class Book { String title }");
+    PsiFile file = configureByDomain("""
+                                       class Library {
+                                         def one() {
+                                           Book.find("from Book b where b.title = ?", ['x'])
+                                         }
+                                       }
+                                       """);
+    assertInjectedLanguage(file, "from Book b where b.title = ?", HQL_LANGUAGE_ID);
+  }
+
+  public void testUnqualifiedCallInsideDomainIsInjected() {
+    PsiFile file = configureByDomain("""
+                                       class Book {
+                                         String title
+                                         static run() {
+                                           findAll("from Book b where b.title = 'x'")
+                                         }
+                                       }
+                                       """);
+    assertInjectedLanguage(file, "from Book b where b.title = 'x'", HQL_LANGUAGE_ID);
+  }
+
+  public void testNonQueryMethodIsNotInjected() {
+    addDomain("class Book { String title }");
+    PsiFile file = configureByDomain("""
+                                       class Library {
+                                         def go() {
+                                           Book.doSomething("from Book b where b.title = 'x'")
+                                         }
+                                       }
+                                       """);
+    assertNoInjection(file, "from Book b where b.title = 'x'");
+  }
+
+  public void testCallOnNonDomainIsNotInjected() {
+    addSimpleGroovyFile("class NotADomain { static executeQuery(String q) {} }");
+    PsiFile file = configureByDomain("""
+                                       class Library {
+                                         def go() {
+                                           NotADomain.executeQuery("from Book b where b.title = 'x'")
+                                         }
+                                       }
+                                       """);
+    assertNoInjection(file, "from Book b where b.title = 'x'");
+  }
+
+  private void assertInjectedLanguage(PsiFile file, String literalContent, String expectedLanguageId) {
+    GrLiteral literal = findStringLiteral(file, literalContent);
+    List<Pair<PsiElement, TextRange>> injected =
+      InjectedLanguageManager.getInstance(getProject()).getInjectedPsiFiles(literal);
+    assertNotNull("Expected an injected language in " + literalContent, injected);
+    assertFalse("Expected an injected language in " + literalContent, injected.isEmpty());
+    assertEquals(expectedLanguageId, injected.get(0).first.getContainingFile().getLanguage().getID());
+  }
+
+  private void assertNoInjection(PsiFile file, String literalContent) {
+    GrLiteral literal = findStringLiteral(file, literalContent);
+    List<Pair<PsiElement, TextRange>> injected =
+      InjectedLanguageManager.getInstance(getProject()).getInjectedPsiFiles(literal);
+    assertTrue("Expected no injection in " + literalContent, injected == null || injected.isEmpty());
+  }
+
+  private static GrLiteral findStringLiteral(PsiFile file, String content) {
+    for (GrLiteral literal : PsiTreeUtil.findChildrenOfType(file, GrLiteral.class)) {
+      Object value = literal.getValue();
+      if (value instanceof String && value.equals(content)) {
+        return literal;
+      }
+    }
+    throw new AssertionError("String literal not found: " + content);
+  }
+}


### PR DESCRIPTION
  Restores, for **Grails 3+** (Gradle) projects, the behavior that already existed on Grails 2.x:

  - **Ctrl+click** on a domain class name inside an HQL query navigates to the class.
  - **Rename** of a domain property/class updates the references inside HQL strings.

  The feature depends on two independent things, and on Grails 3+ **both** were broken:

  1. **HQL language injection into the string** — the old injection (IntelliLang, `languageInjections.xml`) only matched synthetic methods marked with the `DOMAIN_DYNAMIC_METHOD` kind, which
  are only generated for GORM < 4. On GORM 4+ the finders (`find`/`findAll`/`executeQuery`/`executeUpdate`) come from the `GormEntity` trait and aren't marked that way, so the injection
  never fired.
  2. **Resolving names inside the HQL** — the JPA persistence model HQL uses to resolve identifiers is only populated if the module has a Hibernate/JPA facet. That facet is only added by the
  legacy Grails 2.x structure-sync path, which doesn't run for Grails 3+ modules imported via Gradle.

  ## Changes

  - **`GormHqlInjector`** (new) — a programmatic `MultiHostInjector` that injects HQL by resolving the domain class directly (`GormUtils.isGormBean`) instead of relying on the synthetic
  method marker. Works across all GORM versions.
  - **`languageInjections.xml`** — removes the old IntelliLang injection (avoids double injection on GORM < 4).
  - **`Grails3HibernateFacetActivity`** (new) — a `postStartupActivity` in the `:hibernate` module that adds a `"Gorm"` Hibernate facet (idempotent) to every Grails 3+ app module, activating
  the existing persistence bridge (`GormSessionFactoryContributor` → `GormPersistenceMapping` → `GormEntity`).
  - Registered the new components in `plugin.xml` and in the `:hibernate` module descriptor.

  ## Test plan

  - [x] `./gradlew compileJava` and `:hibernate:compileJava` — succeed.
  - [x] `./gradlew test --tests 'GormHqlInjectionTest'` — 5/5 tests passing (cover injection on `find`/`executeQuery`, an unqualified call inside the domain class, and the negative cases: a
  non-finder method and a non-domain qualifier).
  - [x] `./gradlew rat` — new files approved (`AL`), no pending license issues.
  - [ ] Manual validation on a real Grails 3+ project (`./gradlew runIde`): confirm the "Gorm" Hibernate facet appears in Project Structure, Ctrl+click navigates to the domain class inside
  `executeQuery`, and renaming a property updates the query.
