### PR TITLE
Stop injecting Grails 1.x controller members over the traits.

### DIFF
--- a/plugin/src/main/java/org/apache/grails/intellij/plugin/references/controller/ControllerMembersProvider.java
+++ b/plugin/src/main/java/org/apache/grails/intellij/plugin/references/controller/ControllerMembersProvider.java
@@ -96,6 +96,15 @@ public class ControllerMembersProvider extends MemberProvider {
 
   public static final String MIME_API_CLASS = "org.codehaus.groovy.grails.plugins.web.api.ControllersMimeTypesApi";
 
+  /**
+   * Marker for the trait-based controller model of Grails 3 and later. Its super-traits
+   * ({@code ResponseRenderer}, {@code ResponseRedirector}, {@code RequestForwarder}, {@code DataBinder},
+   * {@code WebAttributes}, {@code ServletAttributes}) declare every member {@link #CLASS_SOURCE} used to
+   * inject, and Grails3TraitInjectorContributor already adds the trait as a supertype of each controller,
+   * so those members are real code members there.
+   */
+  private static final String CONTROLLER_TRAIT_CLASS = "grails.artefact.Controller";
+
   @Override
   public void processMembers(PsiScopeProcessor processor, PsiClass psiClass, GrReferenceExpression ref) {
     PsiScopeProcessor executeProcessor = processor;
@@ -131,10 +140,14 @@ public class ControllerMembersProvider extends MemberProvider {
         if (!GrailsPsiUtil.enhance(executeProcessor, controllerRestApiClass, objectType, CONTROLLER_METHOD_KIND)) return;
       }
     }
-    else {
-      // Grails version < 1.4
+    else if (facade.findClass(CONTROLLER_TRAIT_CLASS, resolveScope) == null) {
+      // Grails version < 1.4: no API classes and no controller trait, so nothing declares these members
       if (!DynamicMemberUtils.process(executeProcessor, psiClass, ref, CLASS_SOURCE)) return;
     }
+    // Grails 3+ needs no injection here: contributing CLASS_SOURCE on top of the trait members made every
+    // named-argument call ambiguous ("Method call is ambiguous" on render(view: '...') under
+    // @CompileStatic/@GrailsCompileStatic), because the injected render(Map, Closure = null) is applicable
+    // to the same call as the trait's render(Map) and neither is more specific.
 
     if (!GspTagLibUtil.processGrailsTags(processor, ref, ResolveState.initial(), ResolveUtil.getNameHint(processor), classHint)) return;
   }

--- a/plugin/src/test/java/org/apache/grails/intellij/plugin/v3/GrailsControllerTraitMembersTest.java
+++ b/plugin/src/test/java/org/apache/grails/intellij/plugin/v3/GrailsControllerTraitMembersTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package org.apache.grails.intellij.plugin.v3;
+
+import com.intellij.codeInsight.daemon.impl.HighlightInfo;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.plugins.groovy.LightGroovyTestCase;
+import org.jetbrains.plugins.groovy.codeInspection.assignment.GroovyAssignabilityCheckInspection;
+import org.jetbrains.plugins.groovy.lang.psi.api.GroovyResolveResult;
+import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.GrReferenceExpression;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A Grails 3+ controller carries the {@code grails.artefact.Controller} trait, so
+ * {@code render}/{@code redirect}/{@code params} are real code members. ControllerMembersProvider must not
+ * inject its Grails 1.x replacements on top of them: a second applicable {@code render(Map, Closure = null)}
+ * left {@code render(view: '...')} reported as "Method call is ambiguous" under static compilation.
+ */
+public class GrailsControllerTraitMembersTest extends LightGroovyTestCase {
+
+  private final GrailsProjectDescriptor projectDescriptor = new GrailsProjectDescriptor("grails-app/controllers/");
+
+  @Override
+  public final @NotNull GrailsProjectDescriptor getProjectDescriptor() {
+    return projectDescriptor;
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    getFixture().addClass("""
+                            package grails.artefact;
+                            public @interface Enhances { String[] value(); }
+                            """);
+    getFixture().addClass("""
+                            package groovy.transform;
+                            public @interface CompileStatic {}
+                            """);
+    getFixture().addClass("""
+                            package groovy.lang;
+                            public abstract class Closure<V> {}
+                            """);
+    getFixture().addClass("""
+                            package groovy.lang;
+                            public interface Writable {}
+                            """);
+    // The overload set of grails.artefact.controller.support.ResponseRenderer, applied to controllers
+    // through grails.artefact.Controller
+    getFixture().addFileToProject("grails/artefact/controller/support/ResponseRenderer.groovy", """
+      package grails.artefact.controller.support
+
+      @grails.artefact.Enhances("Controller")
+      trait ResponseRenderer {
+        void render(Object o) {}
+        void render(String txt) {}
+        void render(CharSequence txt) {}
+        void render(Map args) {}
+        void render(Closure c) {}
+        void render(Map args, Closure c) {}
+        void render(Map args, CharSequence body) {}
+        void render(Map args, Writable body) {}
+      }
+      """);
+    getFixture().addFileToProject("grails/artefact/controller/support/ResponseRedirector.groovy", """
+      package grails.artefact.controller.support
+
+      @grails.artefact.Enhances("Controller")
+      trait ResponseRedirector {
+        void redirect(Object o) {}
+        void redirect(Map args) {}
+      }
+      """);
+    getFixture().addFileToProject("grails/artefact/Controller.groovy", """
+      package grails.artefact
+
+      trait Controller implements grails.artefact.controller.support.ResponseRenderer,
+                                  grails.artefact.controller.support.ResponseRedirector {}
+      """);
+  }
+
+  private void configureController(String statement) {
+    PsiFile file = getFixture().addFileToProject("com/bar/CccController.groovy", """
+      package com.bar
+
+      @groovy.transform.CompileStatic
+      class CccController {
+        String errorPage = 'error'
+
+        def index() {
+          """ + statement + """
+
+        }
+      }
+      """);
+    getFixture().configureFromExistingVirtualFile(file.getVirtualFile());
+    getFixture().enableInspections(GroovyAssignabilityCheckInspection.class);
+  }
+
+  private @NotNull List<PsiMethod> resolveCandidates(String methodName) {
+    GrReferenceExpression ref = null;
+    for (GrReferenceExpression candidate : PsiTreeUtil.findChildrenOfType(getFixture().getFile(), GrReferenceExpression.class)) {
+      if (methodName.equals(candidate.getReferenceName())) {
+        ref = candidate;
+        break;
+      }
+    }
+    assertNotNull(methodName + "() call not found", ref);
+
+    List<PsiMethod> methods = new ArrayList<>();
+    for (GroovyResolveResult result : ref.multiResolve(false)) {
+      PsiElement element = result.getElement();
+      if (element instanceof PsiMethod method) methods.add(method);
+    }
+    return methods;
+  }
+
+  private void assertNoAmbiguity(String methodName) {
+    List<PsiMethod> candidates = resolveCandidates(methodName);
+    assertEquals(methodName + "() must resolve to the single trait method, got " + describe(candidates),
+                 1, candidates.size());
+    assertEquals("com.bar.CccController", candidates.get(0).getContainingClass().getQualifiedName());
+
+    for (HighlightInfo info : getFixture().doHighlighting()) {
+      String description = info.getDescription();
+      assertFalse("unexpected highlight: " + description,
+                  description != null && description.contains("ambiguous"));
+    }
+  }
+
+  private static String describe(List<PsiMethod> methods) {
+    StringBuilder sb = new StringBuilder();
+    for (PsiMethod method : methods) {
+      if (!sb.isEmpty()) sb.append("; ");
+      sb.append(method.getContainingClass() == null ? "<none>" : method.getContainingClass().getQualifiedName())
+        .append('#').append(method.getName()).append(method.getParameterList().getText());
+    }
+    return sb.toString();
+  }
+
+  public void testRenderViewNamedArgument() {
+    configureController("render(view: errorPage)");
+    assertNoAmbiguity("render");
+  }
+
+  public void testRenderTextNamedArgument() {
+    configureController("render(text: 'hello')");
+    assertNoAmbiguity("render");
+  }
+
+  public void testRenderExplicitMap() {
+    configureController("render([view: errorPage] as Map)");
+    assertNoAmbiguity("render");
+  }
+
+  public void testRedirectNamedArguments() {
+    configureController("redirect(controller: 'ccc', action: 'index')");
+    assertNoAmbiguity("redirect");
+  }
+}


### PR DESCRIPTION
  ## Problem

  In a Grails 3+ project, a named-argument call to `render` inside a controller is flagged
  as an error even though the code compiles and runs:

  ```groovy
  @GrailsCompileStatic
  class ErrorController {

      def index() {
          try {
              doSomething()
          } catch (Exception e) {
              log.error(e.message)
              render(view: errorPage)   // <- "Method call is ambiguous"
          }
      }
  }
  ```

  The usual workaround is to force a positional argument, which resolves cleanly but is
  noise in the source:

  ```groovy
  render([view: errorPage] as Map)   // no error
  ```

  The same problem applies to other named-argument controller calls, e.g.
  `redirect(controller: 'foo', action: 'index')`.

  ## Root cause

  `ControllerMembersProvider` decided which members to contribute by probing for a single
  Grails 1.x/2.x class:

  ```java
  PsiClass apiClass = facade.findClass("org.codehaus.groovy.grails.plugins.web.api.ControllersApi", resolveScope);
  if (apiClass != null) {
    // Grails >= 1.4: enhance from the *Api classes
  }
  else {
    // assumed "Grails < 1.4": inject CLASS_SOURCE
    DynamicMemberUtils.process(executeProcessor, psiClass, ref, CLASS_SOURCE);
  }
  ```

  That class no longer exists in Grails 3+, so every modern project fell into the legacy
  branch and got `CLASS_SOURCE` injected — including:

  ```java
  " private void render(Map params, Closure cl = null){...}"
  ```

  Meanwhile Grails 3+ controllers already carry `grails.artefact.Controller`
  (`ResponseRenderer`, `ResponseRedirector`, `RequestForwarder`, `DataBinder`,
  `WebAttributes`, `ServletAttributes`), which `Grails3TraitInjectorContributor` adds as a
  supertype — so `render(Map)` is a real code member of the class.

  The call therefore had two applicable candidates and neither is more specific. Resolution
  probe on `render(view: page)` before the fix:

  ```
  candidates=2
    com.bar.CccController#render(java.util.Map)             [GrTraitMethod]             applicable=true
    <none>#render(java.util.Map, groovy.lang.Closure)        [GrDynamicMethodWithCache]  applicable=true
    highlight[ERROR]: Method call is ambiguous
  ```

  And the same probe on `render([view: page] as Map)`:

  ```
  candidates=1
    com.bar.CccController#render(java.util.Map)             [GrTraitMethod]
    (no error)
  ```

  which is exactly why the `as Map` workaround appeared to help — the injected dynamic
  method simply stops being a candidate for a positional argument.

  ## Fix

  Do not contribute the legacy members when the trait-based controller model is present:

  ```java
  else if (facade.findClass(CONTROLLER_TRAIT_CLASS, resolveScope) == null) {
    // Grails version < 1.4: no API classes and no controller trait, so nothing declares these members
    if (!DynamicMemberUtils.process(executeProcessor, psiClass, ref, CLASS_SOURCE)) return;
  }
  ```

  Nothing is lost on Grails 3+. Verified against `grails-plugin-controllers` /
  `grails-web-common` 6.2.3 with `javap`: every member `CLASS_SOURCE` provided is declared
  by the trait set — `render`, `redirect`, `chain`, `forward`, `bindData`, `withForm`,
  `withFormat`, `hasErrors`, `errors`, `modelAndView`, `templateUri`, `viewUri`, plus
  `params`, `request`, `response`, `session`, `flash`, `servletContext`, `grailsApplication`
  and `webRequest`. The legacy versions were in fact worse: the injected `getParams()`
  returns `org.codehaus.groovy.grails.web.servlet.mvc.GrailsParameterMap`, a type that does
  not exist in Grails 3+.

  Behaviour for Grails < 1.4 and for 1.4–2.x is unchanged: the first branch still probes
  `ControllersApi`, and the legacy injection still runs when neither the API classes nor the
  controller trait are on the classpath.

  ## Tests

  New `GrailsControllerTraitMembersTest` (light fixture, `grails-app/controllers/` source
  root) declares the traits with `@grails.artefact.Enhances("Controller")`, which is the hook
  the plugin itself uses to inject them, so the real resolution path is exercised. Each case
  asserts that the call resolves to exactly one method — the trait's — and that no
  `ambiguous` highlight is produced:

  - `render(view: errorPage)` — the reported symptom
  - `render(text: 'hello')` — shows it is not specific to `view:`, and covers a gap in
    `GrailsControllerAmbiguousMethodInspectionTest`, which exercises that same snippet only
    on the Grails 1.4 fixture
  - `render([view: errorPage] as Map)` — keeps the positional form clean
  - `redirect(controller: 'ccc', action: 'index')` — same defect with identical arity

  With the fix reverted, the test fails and names the duplicate:

  ```
  render() must resolve to the single trait method, got
    com.bar.CccController#render(Map args); <none>#render(Map params, Closure cl = null)
  ```

  ## Out of scope

  Inner-closure support for `withFormat { html { } json { } }` is still keyed to
  `lightMethodKey="ControllerMembersProvider_controller_method"`
  (`grails-method-descriptors.xml`), which only exists on the Grails 1.x/2.x paths. On
  Grails 3+ that would need a `methodDescriptor` for `grails.artefact.Controller#withFormat`.
  This is a pre-existing gap — with the call ambiguous it could not resolve at all — and is
  left for a separate change.
