### PR TITLE
fix: harden SAXBuilder against XXE in plugin.xml parsing

### DIFF
--- a/plugin/src/main/java/org/apache/grails/intellij/plugin/mvc/plugins/MvcPluginUtil.java
+++ b/plugin/src/main/java/org/apache/grails/intellij/plugin/mvc/plugins/MvcPluginUtil.java
@@ -89,6 +89,22 @@ public final class MvcPluginUtil {
 
   private MvcPluginUtil() { }
 
+  /**
+   * Plugin descriptor files are untrusted input: they come from the project's own plugin
+   * directories and may originate from a third-party plugin. A default SAXBuilder resolves
+   * DOCTYPE declarations and external entities, which lets a crafted plugin.xml read local
+   * files or trigger SSRF. Disallowing DOCTYPE outright also blocks external entities, since
+   * an entity can only be declared inside one.
+   */
+  private static SAXBuilder createSecureSaxBuilder() {
+    SAXBuilder builder = new SAXBuilder();
+    builder.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    builder.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    builder.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    builder.setExpandEntities(false);
+    return builder;
+  }
+
   private static void setProxyOld(final @NotNull ProxyConfiguration proxyConfig,
                                   final @Nullable Credentials credentials,
                                   @NotNull OldGrailsApplication application) {
@@ -278,7 +294,7 @@ public final class MvcPluginUtil {
     try {
       in = file.getInputStream();
 
-      Document document = new SAXBuilder().build(in);
+      Document document = createSecureSaxBuilder().build(in);
 
       Element root = document.getRootElement();
 
@@ -381,7 +397,7 @@ public final class MvcPluginUtil {
     Element root;
 
     try {
-      Document document = new SAXBuilder().build(inputStream);
+      Document document = createSecureSaxBuilder().build(inputStream);
       root = document.getRootElement();
     }
     catch (JDOMException e) {


### PR DESCRIPTION
Fixes #412.

`MvcPluginUtil.parsePluginList` and `parsePluginXml` both parsed XML with a
default `SAXBuilder`, which resolves DOCTYPE declarations and external
entities. A crafted `plugin.xml` shipped in a project's plugin directory
could use an external entity to read local files or reach an
attacker-controlled host, and this runs as soon as the Grails plugins
dialog is opened or plugin-name completion looks at the plugin
descriptors.

Both call sites now build their `Document` through a shared
`createSecureSaxBuilder()` helper that disallows DOCTYPE declarations
outright (`disallow-doctype-decl`), which also blocks external entities
since they can only be declared inside a DOCTYPE. A normal, well-formed
`plugin.xml` without a DOCTYPE is unaffected.

**Verification.** I don't have the IntelliJ Platform SDK set up locally
(the Gradle build pulls a multi-GB platform distribution), so I could not
run this module's own test suite. Instead I reproduced the issue directly
against the same JDOM APIs used here, outside the plugin: an unhardened
`SAXBuilder` reading a `plugin.xml` with `<!ENTITY xxe SYSTEM "file://...">`
embeds the referenced file's contents into the parsed document; the same
document against a builder configured the way this PR configures it throws
`JDOMParseException: DOCTYPE is disallowed...` instead, and a normal
`plugin.xml` with no DOCTYPE still parses correctly through the hardened
builder. Happy to run the actual test suite if someone can point me at a
faster way to get the platform SDK, or if a maintainer wants to run it
before merging.
